### PR TITLE
Fix !cf and !github commands

### DIFF
--- a/src/main/java/com/github/fabricservertools/discord/listeners/CommandListeners.java
+++ b/src/main/java/com/github/fabricservertools/discord/listeners/CommandListeners.java
@@ -12,13 +12,13 @@ public class CommandListeners extends ListenerAdapter {
     public void onMessageReceived(@NotNull MessageReceivedEvent event) {
         String message = event.getMessage().getContentDisplay();
         if (!message.startsWith("!")) return;
-        message = message.replaceFirst("!", "");
+        message = message.substring(1);
         if (message.equals("help")) {
             LinkCommands.sendHelpCommand(event.getChannel());
-        } else if (message.startsWith("cf")) {
-            LinkCommands.sendCfLink(event.getChannel(), message.replace("cf ", ""));
-        } else if (message.startsWith("github")) {
-            LinkCommands.sendGithubLink(event.getChannel(), message.replace("github ", ""));
+        } else if (message.startsWith("cf ")) {
+            LinkCommands.sendCfLink(event.getChannel(), message.substring("cf ".length()));
+        } else if (message.startsWith("github ")) {
+            LinkCommands.sendGithubLink(event.getChannel(), message.substring("github ".length()));
         } else if (message.startsWith("stop") && (event.getChannel().getName().equals("bot") || Objects.requireNonNull(event.getMember()).isOwner())) {
             event.getChannel().sendMessage("Stopping FabricServerToolsBot").queue();
             event.getJDA().shutdownNow();


### PR DESCRIPTION
This makes the command parser use `.substring` instead of `.replace`.
This makes it possible to do `!github github linguist`, for example.